### PR TITLE
Changed BPM from int to float

### DIFF
--- a/src/gl_global.gd
+++ b/src/gl_global.gd
@@ -7,7 +7,7 @@ var music: AudioStreamPlayer
 var current_chart: Array = []
 
 # Chart Settings
-var bpm: int
+var bpm: float
 var offset: float
 var note_speed: float = 200
 var difficulty_index: int


### PR DESCRIPTION
Allows float values to be used for charter BPM

- I changed gl_global.gd's BPM from an int to a float
- to see if it worked i opened up a chart with BPM 130.5 with no offset and used pg down to get to exactly 1:00, the beat there was 130.5
Fixes issue #5 