### PR TITLE
Duplicate notes

### DIFF
--- a/src/gl_global.gd
+++ b/src/gl_global.gd
@@ -69,3 +69,5 @@ func find_lowest_factor(n: int) -> int:
 			return i  # return the lowest factor
 		i += 1  # increment i to check the next integer
 	return n  # if no factor is found, n is a prime number
+func round_to_dec(num, digit):
+	return round(num * pow(10.0, digit)) / pow(10.0, digit)

--- a/src/gl_global.gd
+++ b/src/gl_global.gd
@@ -69,5 +69,3 @@ func find_lowest_factor(n: int) -> int:
 			return i  # return the lowest factor
 		i += 1  # increment i to check the next integer
 	return n  # if no factor is found, n is a prime number
-func round_to_dec(num, digit):
-	return round(num * pow(10.0, digit)) / pow(10.0, digit)

--- a/src/gl_timeline.gd
+++ b/src/gl_timeline.gd
@@ -24,7 +24,8 @@ func create_note(key: int):
 		note_creation_timestamp = Global.get_synced_song_pos()
 	# Check Note Exists
 	for note in Global.current_chart:
-		if note['timestamp'] == note_creation_timestamp:
+		if Global.round_to_dec(note['timestamp'], 3) == Global.round_to_dec(note_creation_timestamp, 3):
+			print(Global.round_to_dec(note_creation_timestamp, 3))
 			print('Note already exists at %s' % [Global.get_synced_song_pos()])
 			return
 	

--- a/src/gl_timeline.gd
+++ b/src/gl_timeline.gd
@@ -25,7 +25,6 @@ func create_note(key: int):
 	# Check Note Exists
 	for note in Global.current_chart:
 		if Global.round_to_dec(note['timestamp'], 3) == Global.round_to_dec(note_creation_timestamp, 3):
-			print(Global.round_to_dec(note_creation_timestamp, 3))
 			print('Note already exists at %s' % [Global.get_synced_song_pos()])
 			return
 	

--- a/src/gl_timeline.gd
+++ b/src/gl_timeline.gd
@@ -24,7 +24,7 @@ func create_note(key: int):
 		note_creation_timestamp = Global.get_synced_song_pos()
 	# Check Note Exists
 	for note in Global.current_chart:
-		if Global.round_to_dec(note['timestamp'], 3) == Global.round_to_dec(note_creation_timestamp, 3):
+		if snappedf(note['timestamp'], 0.001) == snappedf(note_creation_timestamp, 0.001):
 			print('Note already exists at %s' % [Global.get_synced_song_pos()])
 			return
 	


### PR DESCRIPTION
Fixes issue #11 
Rounded the check for duplicate notes to 3 decimal points

Tested by spamming notes for on an already chart filled between beats 0 and 16 at a 1 beat snap interval to check if any duplicates occurred I saved the chart, changed difficulty, went back into it and checked the top right for if there was above 17 notes, there wasn't. I did the same for 1/2 checking for 33, notes 1/4 65 notes etc. before the changes it was common to be able to place around 50% more than notes there was meant to be, after it seems to be fixed completely